### PR TITLE
Split up selector 'app' into name and env

### DIFF
--- a/templates/openshift/template.yml
+++ b/templates/openshift/template.yml
@@ -28,7 +28,8 @@ objects:
           targetPort: {% raw %}${{svc_port}}{% endraw +%}
           name: http
       selector:
-        app: "{{app_name}}-${env}"
+        app: "{{app_name}}"
+        env: ${env}
       clusterIP:
       type: ClusterIP
       sessionAffinity: None
@@ -54,12 +55,13 @@ objects:
       replicas: {{replicas}}
       selector:
         matchLabels:
-          app: "{{app_name}}-${env}"
+          app: "{{app_name}}"
+          env: ${env}
       template:
         metadata:
           creationTimestamp: null
           labels:
-            app: "{{app_name}}-${env}"
+            app: "{{app_name}}"
             deploymentconfig: "{{app_name}}-${env}"
             env: ${env}
           annotations:


### PR DESCRIPTION
This groups the different envs of a component together as the same app(lication).
A specific env is then defined by the selector/label 'env'. This makes filtering
in Kibana so that it returns the logs of all the different envs for a certain
component easier.