### PR TITLE
DEV-1988 Write OpenShift resources in a dotfolder

### DIFF
--- a/concepts_creator.py
+++ b/concepts_creator.py
@@ -61,7 +61,7 @@ def group():
     "-o",
     "--output-folder",
     default=".",
-    help="The folder of the project the files to. The files will be written in a subfolder 'openshift'.",
+    help="The folder of the project the files to. The files will be written in a subfolder '.openshift'.",
     type=click.Path(file_okay=False, writable=True),
     show_default=True,
 )
@@ -173,7 +173,7 @@ def create(
 
     """
     # Assemble openshift folder to write to.
-    openshift_folder = os.path.join(output_folder, "openshift")
+    openshift_folder = os.path.join(output_folder, ".openshift")
     # Create openshift subfolder if it not yet exists.
     Path(openshift_folder).mkdir(parents=True, exist_ok=True)
 

--- a/templates/jenkins/Jenkinsfile
+++ b/templates/jenkins/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
         }
         stage('Test code') {
             steps {
-                sh 'make -f ./openshift/Makefile test'
+                sh 'make -f ./.openshift/Makefile test'
             }
         }
         stage('Build code') {

--- a/templates/jenkins/multibranch-pipeline.xml
+++ b/templates/jenkins/multibranch-pipeline.xml
@@ -1,18 +1,18 @@
 <?xml version='1.1' encoding='UTF-8'?>
 <org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject plugin="workflow-multibranch">
-    <actions/>
+    <actions />
     <description>Job for {{app_name}}</description>
     <properties>
         <org.jenkinsci.plugins.docker.workflow.declarative.FolderConfig plugin="docker-workflow">
             <dockerLabel></dockerLabel>
-            <registry plugin="docker-commons"/>
+            <registry plugin="docker-commons" />
         </org.jenkinsci.plugins.docker.workflow.declarative.FolderConfig>
         <org.csanchez.jenkins.plugins.kubernetes.KubernetesFolderProperty plugin="kubernetes">
-            <permittedClouds/>
+            <permittedClouds />
         </org.csanchez.jenkins.plugins.kubernetes.KubernetesFolderProperty>
     </properties>
     <folderViews class="jenkins.branch.MultiBranchProjectViewHolder" plugin="branch-api">
-        <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.."/>
+        <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.." />
     </folderViews>
     <healthMetrics>
         <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric plugin="cloudbees-folder">
@@ -20,14 +20,14 @@
         </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
     </healthMetrics>
     <icon class="jenkins.branch.MetadataActionFolderIcon" plugin="branch-api">
-        <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.."/>
+        <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.." />
     </icon>
     <orphanedItemStrategy class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy" plugin="cloudbees-folder">
         <pruneDeadBranches>true</pruneDeadBranches>
         <daysToKeep>-1</daysToKeep>
         <numToKeep>-1</numToKeep>
     </orphanedItemStrategy>
-    <triggers/>
+    <triggers />
     <disabled>false</disabled>
     <sources class="jenkins.branch.MultiBranchProject$BranchSourceList" plugin="branch-api">
         <data>
@@ -46,7 +46,7 @@
                         <org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait>
                             <strategyId>2</strategyId>
                         </org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait>
-                        <org.jenkinsci.plugins.github__branch__source.TagDiscoveryTrait/>
+                        <org.jenkinsci.plugins.github__branch__source.TagDiscoveryTrait />
                         <jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait plugin="scm-api">
                             <includes>{{main_branch}} v*.*.* PR*</includes>
                             <excludes></excludes>
@@ -54,12 +54,12 @@
                     </traits>
                 </source>
                 <strategy class="jenkins.branch.DefaultBranchPropertyStrategy">
-                    <properties class="empty-list"/>
+                    <properties class="empty-list" />
                 </strategy>
                 <buildStrategies>
                     <jenkins.branch.buildstrategies.basic.AllBranchBuildStrategyImpl plugin="basic-branch-build-strategies">
                         <strategies>
-                            <jenkins.branch.buildstrategies.basic.SkipInitialBuildOnFirstBranchIndexing/>
+                            <jenkins.branch.buildstrategies.basic.SkipInitialBuildOnFirstBranchIndexing />
                             <jenkins.branch.buildstrategies.basic.AnyBranchBuildStrategyImpl>
                                 <strategies>
                                     <jenkins.branch.buildstrategies.basic.NamedBranchBuildStrategyImpl>
@@ -85,10 +85,10 @@
                 </buildStrategies>
             </jenkins.branch.BranchSource>
         </data>
-        <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.."/>
+        <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.." />
     </sources>
     <factory class="org.jenkinsci.plugins.workflow.multibranch.WorkflowBranchProjectFactory">
-        <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.."/>
-        <scriptPath>openshift/Jenkinsfile</scriptPath>
+        <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.." />
+        <scriptPath>.openshift/Jenkinsfile</scriptPath>
     </factory>
 </org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject>

--- a/tests/test_concepts_creator.py
+++ b/tests/test_concepts_creator.py
@@ -46,12 +46,12 @@ def test_create(
     assert jenkins_api.call_count == 0
     assert open_shift_api.call_count == 0
 
-    jenkins_multibranch_pipeline.assert_called_once_with(APP_NAME, "./openshift")
+    jenkins_multibranch_pipeline.assert_called_once_with(APP_NAME, "./.openshift")
     j_kwargs = jenkins_multibranch_pipeline().create_concept.call_args.kwargs
     assert j_kwargs["main_branch"] == "main"
     assert UUID(j_kwargs["uuid"], version=4)  # Check if UUID
 
-    open_shift_template.assert_called_once_with(APP_NAME, "./openshift")
+    open_shift_template.assert_called_once_with(APP_NAME, "./.openshift")
     open_shift_template().create_concept.assert_called_once_with(
         **dict(
             namespace=NAMESPACE,
@@ -68,12 +68,12 @@ def test_create(
         )
     )
     # Jenkinsfile
-    jenkins_file.assert_called_once_with(APP_NAME, "./openshift")
+    jenkins_file.assert_called_once_with(APP_NAME, "./.openshift")
     jenkins_file().create_concept.assert_called_once_with(
         **dict(namespace=NAMESPACE, base_image="python:3.7")
     )
     # Makefile
-    make_file.assert_called_once_with(APP_NAME, "./openshift")
+    make_file.assert_called_once_with(APP_NAME, "./.openshift")
     make_file().create_concept.assert_called_once()
 
 


### PR DESCRIPTION
It is custom to put the CI resources in a dotfolder, e.g. `.github` and
`.circleci`. So write the OpenShift resources in `.openshift` instead of
`openshift`.