### PR TITLE
DEV-2130 Remove post step in prd stage of CI/CD

### DIFF
--- a/templates/jenkins/Jenkinsfile
+++ b/templates/jenkins/Jenkinsfile
@@ -125,15 +125,6 @@ pipeline {
                     tagNewImage('prd')
                 }
             }
-            post {
-                always {
-                    script {
-                        previous_tag = sh(script: 'git describe --abbrev=0 --tags `git rev-list --tags --skip=1 --max-count=1`', returnStdout: true).trim()
-                        echo getAllCommitsBetweenTags(previous_tag, env.TAG_NAME)
-                    }
-                    jiraSendDeploymentInfo site: "${JIRA_URL}", environmentId: 'prd', environmentName: 'prd', environmentType: 'production'
-                }
-            }
         }
     }
     post {
@@ -182,12 +173,6 @@ void setGitHubBuildStatus(String message, String state) {
         errorHandlers: [[$class: 'ChangingBuildStatusErrorHandler', result: 'UNSTABLE']],
         statusResultSource: [ $class: 'ConditionalStatusResultSource', results: [[$class: 'AnyBuildResult', message: message, state: state]] ]
     ])
-}
-
-void getAllCommitsBetweenTags(String from, String to) {
-    commit_messages = sh(script: "git log ${from}...${to} --merges --format=%b", returnStdout: true)
-
-    return commit_messages
 }
 
 void tagNewImage(String environment) {

--- a/templates/jenkins/Jenkinsfile
+++ b/templates/jenkins/Jenkinsfile
@@ -125,6 +125,11 @@ pipeline {
                     tagNewImage('prd')
                 }
             }
+            post {
+                always {
+                    jiraSendDeploymentInfo site: "${JIRA_URL}", environmentId: 'prd', environmentName: 'prd', environmentType: 'production'
+                }
+            }
         }
     }
     post {


### PR DESCRIPTION
This step fetches all the changes between two git tags. But this step fails
if there is no previous git tag or if git is not installed in the default
Docker container.

It should update the JIRA tickets linked to these changes with the PRD build
info but that doesn't happen (correctly) so just remove this step.